### PR TITLE
Fix the blank empty space

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
         <groupId>me.stats</groupId>
         <artifactId>CustomStats</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.2</version>
         <packaging>jar</packaging>
 
         <name>CustomStats</name>

--- a/src/main/java/me/stats/CustomStats/CustomStats.java
+++ b/src/main/java/me/stats/CustomStats/CustomStats.java
@@ -23,7 +23,7 @@ public class CustomStats extends JavaPlugin {
             if (this.getDescription().getVersion().equalsIgnoreCase(version)) {
                 console.info("Your up to date!");
             } else {
-                console.info("There is a new update available. Download it at https://www.spigotmc.org/resources/customstats.88300/.");
+                console.info("There is a new update available. Download it at https://www.spigotmc.org/resources/customstats.88300/!");
             }
         });
 

--- a/src/main/java/me/stats/CustomStats/StatsCommand.java
+++ b/src/main/java/me/stats/CustomStats/StatsCommand.java
@@ -45,7 +45,6 @@ public class StatsCommand implements CommandExecutor, TabExecutor {
                 String statcommand = customStats.getConfig().getString("statcommand");
                 //color code is &
                 p.sendMessage(ChatColor.translateAlternateColorCodes(('&'), statcommand));
-                // for some reason it prints empty air? theres nothing making it do this (i kinda like it though)
             }
         }
         else{

--- a/src/main/java/me/stats/CustomStats/StatsCommand.java
+++ b/src/main/java/me/stats/CustomStats/StatsCommand.java
@@ -21,7 +21,6 @@ public class StatsCommand implements CommandExecutor, TabExecutor {
     public boolean onCommand(CommandSender sender, Command cmd, String alias, String[] args) {
         if (sender instanceof Player) {
             Player p = (Player) sender;
-            p.sendMessage(customStats.getConfig().getString("statcommand:"));
             if (args.length == 1){
                 if (args[0].equals("reload")){
                     //checks for permission

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,3 @@
-statcommand: '&a-----------------------------------------------------&6This server
-  was created on Jan 25 2020.          &a-----------------------------------------------------'
+statcommand: '&a ----------------------------------------------------- &6This server
+  was created on January 25, 2019.                    &6The world is 3.37GB in size.
+  &6                                        Over 1,614 players have joined since.   &a-----------------------------------------------------'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 main: me.stats.CustomStats.CustomStats
 author: 7man7LMYT
 website: https://discord.gg/Z5MyDwp
-description: A plugin that adds /stats.
+description: An anarchy server oriented plugin that adds /stats.
 api-version: 1.13
 commands:
   stats:


### PR DESCRIPTION
Accidentally left in a bit of code that read from a config section that didnt exist, 👀 note to self: remember to delete things that dont work xd

this fixes the empty space sent before the stats command prints whatever it needs to